### PR TITLE
Allow for the detection of a tap event

### DIFF
--- a/PWParallaxScrollView/PWParallaxScrollView.h
+++ b/PWParallaxScrollView/PWParallaxScrollView.h
@@ -42,6 +42,7 @@
 @optional
 - (void)parallaxScrollView:(PWParallaxScrollView *)scrollView didChangeIndex:(NSInteger)index;
 - (void)parallaxScrollView:(PWParallaxScrollView *)scrollView didEndDeceleratingAtIndex:(NSInteger)index;
+- (void)parallaxScrollView:(PWParallaxScrollView *)scrollView didRecieveTapAtIndex:(NSInteger)index;
 
 @end
 

--- a/PWParallaxScrollView/PWParallaxScrollView.m
+++ b/PWParallaxScrollView/PWParallaxScrollView.m
@@ -23,6 +23,9 @@ static const NSInteger PWInvalidPosition = -1;
 @property (nonatomic, strong) UIView *currentBottomView;
 
 @property (nonatomic, assign) NSInteger currentIndex;
+
+- (void)touchScrollViewTapped:(id)sender;
+
 @end
 
 @implementation PWParallaxScrollView
@@ -70,6 +73,10 @@ static const NSInteger PWInvalidPosition = -1;
     _touchScrollView.backgroundColor = [UIColor clearColor];
     _touchScrollView.contentOffset = CGPointMake(0, 0);
     _touchScrollView.multipleTouchEnabled = YES;
+    
+    UITapGestureRecognizer *tapGestureRecognize = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(touchScrollViewTapped:)];
+    tapGestureRecognize.numberOfTapsRequired = 1;
+    [_touchScrollView addGestureRecognizer:tapGestureRecognize];
     
     self.foregroundScrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
     _foregroundScrollView.scrollEnabled = NO;
@@ -138,6 +145,12 @@ static const NSInteger PWInvalidPosition = -1;
 }
 
 #pragma mark - private method
+- (void)touchScrollViewTapped:(id)sender
+{
+    if ([self.delegate respondsToSelector:@selector(parallaxScrollView:didRecieveTapAtIndex:)]) {
+        [self.delegate parallaxScrollView:self didRecieveTapAtIndex:self.currentIndex];
+    }
+}
 
 - (UIView *)foregroundViewAtIndex:(NSInteger)index
 {
@@ -292,7 +305,6 @@ static const NSInteger PWInvalidPosition = -1;
 }
 
 #pragma mark hitTest
-
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     for (UIView *subview in _foregroundScrollView.subviews) {


### PR DESCRIPTION
(great for when you want to show a gallery and click on images without a foreground button in the way)

I really wanted this ability, so I put it in on my end; but I think it would be even better if it was in the pod
